### PR TITLE
Add a .travis.yml to run goapp test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+
+go:
+ - 1.4
+
+install:
+ - wget https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.17.zip
+ - unzip -q go_appengine_sdk_linux_amd64-1.9.17.zip
+ - export PATH=$PATH:$PWD/go_appengine/
+
+script:
+ - goapp test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,6 @@ install:
  - export PATH=$PATH:$PWD/go_appengine/
 
 script:
+ - goapp get code.google.com/p/google-api-go-client/googleapi/transport
+ - goapp get code.google.com/p/google-api-go-client/plus/v1
  - goapp test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ install:
  - export PATH=$PATH:$PWD/go_appengine/
 
 script:
- - goapp get code.google.com/p/google-api-go-client/googleapi/transport
- - goapp get code.google.com/p/google-api-go-client/plus/v1
+ - goapp get ./...
  - goapp test

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-application: goplus
+application: goplus-imjasonh
 version: 1
 runtime: go
 api_version: go1

--- a/app.yaml
+++ b/app.yaml
@@ -1,4 +1,4 @@
-application: goplus-imjasonh
+application: goplus
 version: 1
 runtime: go
 api_version: go1


### PR DESCRIPTION
This demonstrates how an App Engine app can be built and tested using Travis CI, and with a little more work could also be configured to deploy as well after tests pass.

For now the test is a no-op, but it at least demonstrates that it's possible.
